### PR TITLE
[UPDATE] Just separating out Strategy (internal) and Auth (public/ext…

### DIFF
--- a/src/core/auth/factory.ts
+++ b/src/core/auth/factory.ts
@@ -1,7 +1,7 @@
 import type { AuthConfig } from '../../types/config';
 import type { AuthStrategy } from './types';
 import { BasicAuth } from './basic';
-import { SsoAuth, type SsoAuthConfig } from './sso';
+import { SsoAuth, type SsoStrategyConfig } from './sso';
 import { SamlAuth } from './saml';
 
 /**
@@ -69,7 +69,7 @@ export function createAuthStrategy(options: CreateAuthOptions): AuthStrategy {
             });
 
         case 'sso': {
-            const ssoConfig: SsoAuthConfig = {
+            const ssoConfig: SsoStrategyConfig = {
                 slsUrl: config.slsUrl,
             };
             if (config.profile) {

--- a/src/core/auth/index.ts
+++ b/src/core/auth/index.ts
@@ -32,8 +32,9 @@ export type { AuthType, AuthStrategy, AuthCookie, BasicAuthCredentials } from '.
 // Strategy classes
 export { BasicAuth } from './basic';
 export { SamlAuth } from './saml';
-export type { SamlAuthConfig } from './saml';
+export type { SamlStrategyConfig } from './saml';
 export { SsoAuth } from './sso';
+export type { SsoStrategyConfig } from './sso';
 
 // Factory
 export type { CreateAuthOptions } from './factory';

--- a/src/core/auth/saml/index.ts
+++ b/src/core/auth/saml/index.ts
@@ -7,7 +7,7 @@
 
 // Main class and config
 export { SamlAuth } from './saml';
-export type { SamlAuthConfig } from './saml';
+export type { SamlStrategyConfig } from './saml';
 
 // Types
 export type {

--- a/src/core/auth/saml/saml.ts
+++ b/src/core/auth/saml/saml.ts
@@ -44,9 +44,13 @@ import { performBrowserLogin } from './browser';
 import { toAuthCookies, formatCookieHeader } from './cookies';
 
 /**
- * Configuration for SAML authentication
+ * Internal configuration for SAML authentication strategy.
+ *
+ * This differs from the public SamlAuthConfig (in types/config.ts) by:
+ * - No `type` discriminator (strategy already knows it's SAML)
+ * - Includes `baseUrl` (injected by factory from ClientConfig.url)
  */
-export interface SamlAuthConfig {
+export interface SamlStrategyConfig {
     /** SAML username (often an email address) - used for browser login */
     username: string;
     /** SAML password */
@@ -65,14 +69,14 @@ export interface SamlAuthConfig {
 export class SamlAuth implements AuthStrategy {
     readonly type = 'saml' as const;
     private cookies: AuthCookie[] = [];
-    private config: SamlAuthConfig;
+    private config: SamlStrategyConfig;
 
     /**
      * Create a SAML Auth strategy
      *
-     * @param config - SAML authentication configuration
+     * @param config - SAML strategy configuration (with baseUrl)
      */
-    constructor(config: SamlAuthConfig) {
+    constructor(config: SamlStrategyConfig) {
         if (!config.username || !config.password) {
             throw new Error('SamlAuth requires both username and password');
         }

--- a/src/core/auth/sso/index.ts
+++ b/src/core/auth/sso/index.ts
@@ -15,7 +15,7 @@
 
 // Main auth strategy
 export { SsoAuth } from './sso';
-export type { SsoAuthConfig } from './sso';
+export type { SsoStrategyConfig } from './sso';
 
 // Types
 export type {

--- a/src/core/auth/sso/sso.ts
+++ b/src/core/auth/sso/sso.ts
@@ -39,9 +39,13 @@ import { enrollCertificate } from './slsClient';
 import { loadCertificates, saveCertificates, certificatesExist, isCertificateExpired } from './storage';
 
 /**
- * SSO authentication configuration
+ * Internal configuration for SSO authentication strategy.
+ *
+ * This differs from the public SsoAuthConfig (in types/config.ts) by:
+ * - No `type` discriminator (strategy already knows it's SSO)
+ * - Includes `insecure` and `returnContents` (injected by factory)
  */
-export interface SsoAuthConfig {
+export interface SsoStrategyConfig {
     /** Secure Login Server URL */
     slsUrl: string;
     /** SLS profile (default: SAPSSO_P) */
@@ -61,15 +65,15 @@ export interface SsoAuthConfig {
  */
 export class SsoAuth implements AuthStrategy {
     readonly type = 'sso' as const;
-    private config: SsoAuthConfig;
+    private config: SsoStrategyConfig;
     private certificates: CertificateMaterial | null = null;
 
     /**
      * Create an SSO Auth strategy
      *
-     * @param config - SSO authentication configuration
+     * @param config - SSO strategy configuration
      */
-    constructor(config: SsoAuthConfig) {
+    constructor(config: SsoStrategyConfig) {
         if (!config.slsUrl) {
             throw new Error('SsoAuth requires slsUrl');
         }


### PR DESCRIPTION
…ernal) configs since we had interfaces with duplicate names.

Cleanliness no functionality changed at all.