### PR TITLE
Feature/freestyle endpoint

### DIFF
--- a/docs/endpoints/preview.md
+++ b/docs/endpoints/preview.md
@@ -10,6 +10,8 @@ Query and preview data from SAP tables and CDS views.
   - [Library Usage](#library-usage-1)
 - [POST /preview/count](#post-previewcount)
   - [Library Usage](#library-usage-2)
+- [POST /preview/freestyle](#post-previewfreestyle)
+  - [Library Usage](#library-usage-3)
 
 ---
 
@@ -636,6 +638,140 @@ if (err) {
 
 // Safe to use count here
 console.log(`Total rows: ${count}`);
+```
+
+---
+
+## POST /preview/freestyle
+
+Execute arbitrary OpenSQL queries including aggregations, JOINs, GROUP BY, and other full SQL constructs not supported by `/preview/data`.
+
+### Request
+
+| Method | Path | Auth Required |
+|--------|------|---------------|
+| POST | `/preview/freestyle` | Yes |
+
+### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `sqlQuery` | string | Yes | Full OpenSQL SELECT statement |
+| `limit` | number | No | Max rows to return (default: 100, max: 50000) |
+
+### Response
+
+DataFrame structure (same as `/preview/data`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `columns` | array | Column metadata |
+| `rows` | array[] | Row data (array of arrays) |
+| `totalRows` | number? | Total matching rows (if available) |
+
+### Example
+
+**Request:**
+```json
+{
+    "sqlQuery": "SELECT CompanyCode, SUM( AmountInCompanyCodeCurrency ) AS Total FROM ZSNAP_F01S_C01( P_ControllingArea = 'MED1', P_Signage = 'R' ) GROUP BY CompanyCode",
+    "limit": 50
+}
+```
+
+**Response:**
+```json
+{
+    "success": true,
+    "data": {
+        "columns": [
+            { "name": "CompanyCode", "dataType": "CHAR" },
+            { "name": "Total", "dataType": "CURR" }
+        ],
+        "rows": [
+            ["1000", "4521893.50"],
+            ["2000", "1238450.00"]
+        ]
+    }
+}
+```
+### Errors
+
+| Code | Status | Cause |
+|------|--------|-------|
+| `VALIDATION_ERROR` | 400 | Missing or empty `sqlQuery` |
+| `UNKNOWN_ERROR` | 500 | SAP rejected the query — check `details` field for raw SAP error XML |
+
+On error, the response includes a `details` field with the raw SAP XML error response:
+
+```json
+{
+    "success": false,
+    "error": "Freestyle query failed: A Boolean expression was expected in \"MA\".",
+    "code": "UNKNOWN_ERROR",
+    "details": "<?xml version=\"1.0\"...><message>...</message>...</exc:exception>"
+}
+```
+
+### Use Cases
+
+- **Aggregate queries** — `SUM`, `COUNT`, `AVG`, `MIN`, `MAX` across large datasets
+- **GROUP BY analysis** — Breakdown by dimension
+- **CDS view with parameters** — Pass parameters inline in the SQL string
+- **Multi-line SQL** — Complex queries exceeding ABAP's 255-character line limit (use `\n` between clauses)
+
+### Library Usage
+
+When using Catalyst-Relay as a TypeScript library, call `client.freestyleQuery()`:
+
+```typescript
+import { createClient, type AsyncResult, type DataFrame } from 'catalyst-relay';
+
+const [client, createErr] = createClient({
+    url: 'https://sap-server.example.com:443',
+    client: '100',
+    auth: { type: 'basic', username: 'developer', password: 'password' }
+});
+if (createErr) throw createErr;
+
+await client.login();
+
+// Simple aggregate query
+const [dataFrame, err] = await client.freestyleQuery(
+    "SELECT CompanyCode, COUNT(*) AS Cnt\nFROM ZSNAP_F01S_C01( P_ControllingArea = 'MED1', P_Signage = 'R' )\nGROUP BY CompanyCode",
+    100  // optional limit
+);
+
+if (err) {
+    console.error('Query failed:', err.message);
+    process.exit(1);
+}
+
+console.log('Columns:', dataFrame.columns);
+console.log('Rows:', dataFrame.rows);
+```
+
+**Method Signature:**
+
+```typescript
+async freestyleQuery(
+    sqlQuery: string,
+    limit?: number   // default: 100, max: 50000
+): AsyncResult<DataFrame>
+```
+
+**Note on multi-line SQL:** ABAP has a historical 255-character line length limit. For queries longer than ~255 characters, split clauses with `\n`:
+
+```typescript
+const sql = [
+    "SELECT CompanyCode, FiscalYear, SUM( AmountInCompanyCodeCurrency ) AS Total",
+    "FROM ZSNAP_F01S_C01( P_ControllingArea = 'MED1', P_Signage = 'R' )",
+    "WHERE FiscalYear = '2025'",
+    "GROUP BY CompanyCode, FiscalYear",
+    "ORDER BY CompanyCode ASC",
+].join("\n");
+
+const [dataFrame, err] = await client.freestyleQuery(sql);
 ```
 
 ---

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -101,7 +101,7 @@ export interface ADTClient {
     previewData(query: PreviewSQL): AsyncResult<DataFrame>;
     getDistinctValues(objectName: string, parameters: Parameter[], column: string, objectType?: 'table' | 'view'): AsyncResult<DistinctResult>;
     countRows(objectName: string, objectType: 'table' | 'view', parameters?: Parameter[]): AsyncResult<number>;
-    freestyleQuery(sqlQuery: string, limit?: number): AsyncResult<DataFrame>;
+    freestyleQuery(sqlQuery: string, limit?: number, timeout?: number): AsyncResult<DataFrame>;
 
     // Search
     search(query: string, options?: SearchOptions): AsyncResult<SearchResult[]>;
@@ -302,8 +302,8 @@ export class ADTClientImpl implements ADTClient {
         return previewMethods.countRows(this.state, this.requestor, objectName, objectType, parameters);
     }
 
-    async freestyleQuery(sqlQuery: string, limit?: number): AsyncResult<DataFrame> {
-        return previewMethods.freestyleQuery(this.state, this.requestor, sqlQuery, limit);
+    async freestyleQuery(sqlQuery: string, limit?: number, timeout?: number): AsyncResult<DataFrame> {
+        return previewMethods.freestyleQuery(this.state, this.requestor, sqlQuery, limit, timeout);
     }
 
     // --- Search ---

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -101,6 +101,7 @@ export interface ADTClient {
     previewData(query: PreviewSQL): AsyncResult<DataFrame>;
     getDistinctValues(objectName: string, parameters: Parameter[], column: string, objectType?: 'table' | 'view'): AsyncResult<DistinctResult>;
     countRows(objectName: string, objectType: 'table' | 'view', parameters?: Parameter[]): AsyncResult<number>;
+    freestyleQuery(sqlQuery: string, limit?: number): AsyncResult<DataFrame>;
 
     // Search
     search(query: string, options?: SearchOptions): AsyncResult<SearchResult[]>;
@@ -299,6 +300,10 @@ export class ADTClientImpl implements ADTClient {
 
     async countRows(objectName: string, objectType: 'table' | 'view', parameters: Parameter[] = []): AsyncResult<number> {
         return previewMethods.countRows(this.state, this.requestor, objectName, objectType, parameters);
+    }
+
+    async freestyleQuery(sqlQuery: string, limit?: number): AsyncResult<DataFrame> {
+        return previewMethods.freestyleQuery(this.state, this.requestor, sqlQuery, limit);
     }
 
     // --- Search ---

--- a/src/client/methods/internal/request.ts
+++ b/src/client/methods/internal/request.ts
@@ -32,7 +32,7 @@ export async function executeRequest(
     selfRequest: (options: RequestOptions) => AsyncResult<Response, Error>
 ): AsyncResult<Response, Error> {
     const { state, ssoCerts, getCookieHeader, storeCookies } = deps;
-    const { method, path, params, headers: customHeaders, body } = options;
+    const { method, path, params, headers: customHeaders, body, timeout: requestTimeout } = options;
     const { config } = state;
 
     // Build headers with auth and CSRF token
@@ -68,7 +68,7 @@ export async function executeRequest(
             cert: ssoCerts?.cert,
             key: ssoCerts?.key,
             rejectUnauthorized: !config.insecure,
-            timeout: config.timeout ?? DEFAULT_TIMEOUT,
+            timeout: requestTimeout ?? config.timeout ?? DEFAULT_TIMEOUT,
         });
 
 
@@ -100,7 +100,7 @@ export async function executeRequest(
                     cert: ssoCerts?.cert,
                     key: ssoCerts?.key,
                     rejectUnauthorized: !config.insecure,
-                    timeout: config.timeout ?? DEFAULT_TIMEOUT,
+                    timeout: requestTimeout ?? config.timeout ?? DEFAULT_TIMEOUT,
                 });
                 storeCookies(retryResponse);
                 return ok(retryResponse);

--- a/src/client/methods/internal/request.ts
+++ b/src/client/methods/internal/request.ts
@@ -56,6 +56,11 @@ export async function executeRequest(
     const urlParams = buildParams(params, config.client);
     const url = buildUrl(config.url, path, urlParams);
 
+    // Log the outgoing request path (strip sap-client for readability)
+    const displayUrl = new URL(url);
+    displayUrl.searchParams.delete('sap-client');
+    console.log(`--> ${method} ${displayUrl.pathname}${displayUrl.search}`);
+
     try {
         // Execute HTTP request using Node.js https module
         debug(`Fetching URL: ${url}`);
@@ -70,6 +75,8 @@ export async function executeRequest(
             rejectUnauthorized: !config.insecure,
             timeout: config.timeout ?? DEFAULT_TIMEOUT,
         });
+
+        console.log(`<-- ${method} ${displayUrl.pathname}${displayUrl.search} ${response.status}`);
 
         // Store any cookies from response
         storeCookies(response);
@@ -91,6 +98,7 @@ export async function executeRequest(
                     headers['Cookie'] = retryCookieHeader;
                 }
                 debug(`Retrying with new CSRF token: ${newToken.substring(0, 20)}...`);
+                console.log(`--> ${method} ${displayUrl.pathname}${displayUrl.search} (CSRF retry)`);
 
                 const retryResponse = await httpRequest(url, {
                     method,
@@ -101,6 +109,7 @@ export async function executeRequest(
                     rejectUnauthorized: !config.insecure,
                     timeout: config.timeout ?? DEFAULT_TIMEOUT,
                 });
+                console.log(`<-- ${method} ${displayUrl.pathname}${displayUrl.search} ${retryResponse.status}`);
                 storeCookies(retryResponse);
                 return ok(retryResponse);
             }

--- a/src/client/methods/internal/request.ts
+++ b/src/client/methods/internal/request.ts
@@ -59,7 +59,7 @@ export async function executeRequest(
     // Log the outgoing request path (strip sap-client for readability)
     const displayUrl = new URL(url);
     displayUrl.searchParams.delete('sap-client');
-    console.log(`--> ${method} ${displayUrl.pathname}${displayUrl.search}`);
+    // console.log(`--> ${method} ${displayUrl.pathname}${displayUrl.search}`);
 
     try {
         // Execute HTTP request using Node.js https module
@@ -76,7 +76,7 @@ export async function executeRequest(
             timeout: config.timeout ?? DEFAULT_TIMEOUT,
         });
 
-        console.log(`<-- ${method} ${displayUrl.pathname}${displayUrl.search} ${response.status}`);
+        // console.log(`<-- ${method} ${displayUrl.pathname}${displayUrl.search} ${response.status}`);
 
         // Store any cookies from response
         storeCookies(response);
@@ -98,7 +98,7 @@ export async function executeRequest(
                     headers['Cookie'] = retryCookieHeader;
                 }
                 debug(`Retrying with new CSRF token: ${newToken.substring(0, 20)}...`);
-                console.log(`--> ${method} ${displayUrl.pathname}${displayUrl.search} (CSRF retry)`);
+                // console.log(`--> ${method} ${displayUrl.pathname}${displayUrl.search} (CSRF retry)`);
 
                 const retryResponse = await httpRequest(url, {
                     method,
@@ -109,7 +109,7 @@ export async function executeRequest(
                     rejectUnauthorized: !config.insecure,
                     timeout: config.timeout ?? DEFAULT_TIMEOUT,
                 });
-                console.log(`<-- ${method} ${displayUrl.pathname}${displayUrl.search} ${retryResponse.status}`);
+                // console.log(`<-- ${method} ${displayUrl.pathname}${displayUrl.search} ${retryResponse.status}`);
                 storeCookies(retryResponse);
                 return ok(retryResponse);
             }

--- a/src/client/methods/internal/request.ts
+++ b/src/client/methods/internal/request.ts
@@ -56,11 +56,6 @@ export async function executeRequest(
     const urlParams = buildParams(params, config.client);
     const url = buildUrl(config.url, path, urlParams);
 
-    // Log the outgoing request path (strip sap-client for readability)
-    const displayUrl = new URL(url);
-    displayUrl.searchParams.delete('sap-client');
-    // console.log(`--> ${method} ${displayUrl.pathname}${displayUrl.search}`);
-
     try {
         // Execute HTTP request using Node.js https module
         debug(`Fetching URL: ${url}`);
@@ -76,7 +71,6 @@ export async function executeRequest(
             timeout: config.timeout ?? DEFAULT_TIMEOUT,
         });
 
-        // console.log(`<-- ${method} ${displayUrl.pathname}${displayUrl.search} ${response.status}`);
 
         // Store any cookies from response
         storeCookies(response);
@@ -98,7 +92,6 @@ export async function executeRequest(
                     headers['Cookie'] = retryCookieHeader;
                 }
                 debug(`Retrying with new CSRF token: ${newToken.substring(0, 20)}...`);
-                // console.log(`--> ${method} ${displayUrl.pathname}${displayUrl.search} (CSRF retry)`);
 
                 const retryResponse = await httpRequest(url, {
                     method,
@@ -109,7 +102,6 @@ export async function executeRequest(
                     rejectUnauthorized: !config.insecure,
                     timeout: config.timeout ?? DEFAULT_TIMEOUT,
                 });
-                // console.log(`<-- ${method} ${displayUrl.pathname}${displayUrl.search} ${retryResponse.status}`);
                 storeCookies(retryResponse);
                 return ok(retryResponse);
             }

--- a/src/client/methods/preview/freestyleQuery.ts
+++ b/src/client/methods/preview/freestyleQuery.ts
@@ -1,0 +1,19 @@
+/**
+ * Freestyle query method
+ */
+
+import type { AsyncResult } from '../../../types/result';
+import type { AdtRequestor, DataFrame } from '../../../core/adt';
+import type { ClientState } from '../../types';
+import { err } from '../../../types/result';
+import * as adt from '../../../core/adt';
+
+export async function freestyleQuery(
+    state: ClientState,
+    requestor: AdtRequestor,
+    sqlQuery: string,
+    limit?: number
+): AsyncResult<DataFrame> {
+    if (!state.session) return err(new Error('Not logged in'));
+    return adt.freestyleQuery(requestor, sqlQuery, limit);
+}

--- a/src/client/methods/preview/freestyleQuery.ts
+++ b/src/client/methods/preview/freestyleQuery.ts
@@ -12,8 +12,9 @@ export async function freestyleQuery(
     state: ClientState,
     requestor: AdtRequestor,
     sqlQuery: string,
-    limit?: number
+    limit?: number,
+    timeout?: number
 ): AsyncResult<DataFrame> {
     if (!state.session) return err(new Error('Not logged in'));
-    return adt.freestyleQuery(requestor, sqlQuery, limit);
+    return adt.freestyleQuery(requestor, sqlQuery, limit, timeout);
 }

--- a/src/client/methods/preview/index.ts
+++ b/src/client/methods/preview/index.ts
@@ -5,3 +5,4 @@
 export { previewData } from './previewData';
 export { getDistinctValues } from './getDistinctValues';
 export { countRows } from './countRows';
+export { freestyleQuery } from './freestyleQuery';

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -25,6 +25,7 @@ export interface RequestOptions {
     params?: Record<string, string | number>;
     headers?: Record<string, string>;
     body?: string;
+    timeout?: number;
 }
 
 // Request function type

--- a/src/core/adt/data_extraction/freestyle.ts
+++ b/src/core/adt/data_extraction/freestyle.ts
@@ -26,7 +26,8 @@ const DEFAULT_ROW_LIMIT = 100;
 export async function freestyleQuery(
     client: AdtRequestor,
     sqlQuery: string,
-    limit = DEFAULT_ROW_LIMIT
+    limit = DEFAULT_ROW_LIMIT,
+    timeout?: number
 ): AsyncResult<DataFrame, Error> {
     debug(`Freestyle query: ${sqlQuery}`);
 
@@ -41,6 +42,7 @@ export async function freestyleQuery(
             'Content-Type': 'text/plain',
         },
         body: sqlQuery,
+        ...(timeout !== undefined && { timeout }),
     });
 
     if (requestErr) return err(requestErr);

--- a/src/core/adt/data_extraction/freestyle.ts
+++ b/src/core/adt/data_extraction/freestyle.ts
@@ -49,7 +49,7 @@ export async function freestyleQuery(
         const text = await response.text();
         debug(`Freestyle query error response: ${text.substring(0, 500)}`);
         const errorMsg = extractError(text);
-        return err(new Error(`Freestyle query failed: ${errorMsg}`));
+        return err(new Error(`Freestyle query failed: ${errorMsg}`, { cause: text }));
     }
 
     const text = await response.text();

--- a/src/core/adt/data_extraction/freestyle.ts
+++ b/src/core/adt/data_extraction/freestyle.ts
@@ -40,6 +40,10 @@ export async function freestyleQuery(
         headers: {
             'Accept': 'application/xml, application/vnd.sap.adt.datapreview.table.v1+xml',
             'Content-Type': 'text/plain',
+            // Override stateful base header: each preview request is independent; stateless
+            // lets SAP route to any work process and recycle it after the request, preventing
+            // GENERATE_SUBPOOL_DIR_FULL (36-pool limit per work process).
+            'X-sap-adt-sessiontype': 'stateless',
         },
         body: sqlQuery,
         ...(timeout !== undefined && { timeout }),

--- a/src/core/adt/data_extraction/previewParser.ts
+++ b/src/core/adt/data_extraction/previewParser.ts
@@ -104,20 +104,20 @@ export function parseDataPreview(
             }
             allAttrs[attr.name] = attr.value;
         }
-        console.log("All available attributes for this element:", allAttrs);
+        // console.log("All available attributes for this element:", allAttrs);
         if (!name || !dataType) continue;
            
         columns.push({ name, dataType });
     }
 
-    console.log("columns extracted from metadata", columns.length, columns);
+    // console.log("columns extracted from metadata", columns.length, columns);
 
     // Extract data values organized by column.
     const dataSetElements = doc.getElementsByTagNameNS(namespace, 'dataSet');
     // console.log("dataSet", dataSetElements);
 
     for (let i = 0; i < dataSetElements.length; i++) {
-        console.log("dataSet element index", i);
+        // console.log("dataSet element index", i);
         const dataSet = dataSetElements[i];
         if (!dataSet) continue;
     }

--- a/src/core/adt/data_extraction/previewParser.ts
+++ b/src/core/adt/data_extraction/previewParser.ts
@@ -50,7 +50,6 @@ export function parseDataPreview(
     const metadataElements = doc.getElementsByTagNameNS(namespace, 'metadata');
     const columns: ColumnInfo[] = [];
 
-    // console.log("metadata", metadataElements);
     const SAP_TYPE_MAP: Record<string, string> = {
         '8': 'integer',   // Int8
         'I': 'integer',   // Integer
@@ -104,20 +103,16 @@ export function parseDataPreview(
             }
             allAttrs[attr.name] = attr.value;
         }
-        // console.log("All available attributes for this element:", allAttrs);
         if (!name || !dataType) continue;
            
         columns.push({ name, dataType });
     }
 
-    // console.log("columns extracted from metadata", columns.length, columns);
 
     // Extract data values organized by column.
     const dataSetElements = doc.getElementsByTagNameNS(namespace, 'dataSet');
-    // console.log("dataSet", dataSetElements);
 
     for (let i = 0; i < dataSetElements.length; i++) {
-        // console.log("dataSet element index", i);
         const dataSet = dataSetElements[i];
         if (!dataSet) continue;
     }

--- a/src/core/adt/index.ts
+++ b/src/core/adt/index.ts
@@ -77,6 +77,7 @@ export { getInactiveObjects } from './discovery/inactiveObjects';
 
 // Data preview operations
 export { previewData } from './data_extraction/dataPreview';
+export { freestyleQuery } from './data_extraction/freestyle';
 export { getDistinctValues } from './data_extraction/distinct';
 export { countRows } from './data_extraction/count';
 

--- a/src/core/adt/types.ts
+++ b/src/core/adt/types.ts
@@ -10,6 +10,7 @@ export interface AdtRequestor {
         params?: Record<string, string | number>;
         headers?: Record<string, string>;
         body?: string;
+        timeout?: number;
     }): AsyncResult<Response, Error>;
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import { logger } from 'hono/logger';
 import { SessionManager } from './core/session/manager';
 import { startCleanupTask } from './core/session/cleanup';
 import { createSessionMiddleware, errorMiddleware } from './server/middleware';
+import { ApiError } from './server/middleware/error';
 import { createRoutes } from './server/routes';
 import type { ISessionManager } from './server/routes';
 
@@ -23,7 +24,7 @@ const sessionManager = new SessionManager() as unknown as ISessionManager;
 const cleanupHandle = startCleanupTask(
     sessionManager as unknown as SessionManager,
     (sessionManager as unknown as SessionManager).getConfig(),
-    (sessionId, entry) => {
+    (sessionId, _entry) => {
         console.log(`Session ${sessionId} expired after inactivity`);
     }
 );
@@ -53,10 +54,21 @@ app.notFound((c) => {
 // Error handler
 app.onError((error, c) => {
     console.error('Unhandled error:', error);
+    if (error instanceof ApiError) {
+        return c.json(
+            {
+                success: false as const,
+                error: error.message,
+                code: error.code,
+                details: error.details,
+            },
+            error.statusCode as 400 | 401 | 403 | 404 | 500
+        );
+    }
     return c.json(
         {
-            success: false,
-            error: 'Internal server error',
+            success: false as const,
+            error: error instanceof Error ? error.message : 'Internal server error',
             code: 'UNKNOWN_ERROR',
         },
         500

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -39,6 +39,7 @@ import { deleteHandler } from './objects/delete';
 import { dataHandler } from './preview/data';
 import { distinctHandler } from './preview/distinct';
 import { countHandler } from './preview/count';
+import { freestyleHandler } from './preview/freestyle';
 
 // Search routes
 import { searchHandler } from './search/search';
@@ -99,6 +100,7 @@ export function createRoutes(
     app.post('/preview/data', sessionMiddleware, dataHandler);
     app.post('/preview/distinct', sessionMiddleware, distinctHandler);
     app.post('/preview/count', sessionMiddleware, countHandler);
+    app.post('/preview/freestyle', sessionMiddleware, freestyleHandler);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Search Routes (session required)

--- a/src/server/routes/preview/freestyle.ts
+++ b/src/server/routes/preview/freestyle.ts
@@ -1,0 +1,55 @@
+/**
+ * POST /preview/freestyle — Execute arbitrary OpenSQL via the freestyle endpoint
+ */
+
+import { z } from 'zod';
+import type { DataFrame } from '../../../core/adt/data_extraction/previewParser';
+import { ApiError } from '../../middleware/error';
+import { formatZodError } from '../../utils';
+import type { RouteContext } from '../types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Request Schema (colocated)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const freestyleRequestSchema = z.object({
+    sqlQuery: z.string().min(1),
+    limit: z.number().positive().max(50000).optional(),
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Response Type (colocated)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type FreestyleResponse = DataFrame;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Handler
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function freestyleHandler(c: RouteContext) {
+    const body = await c.req.json();
+
+    const validation = freestyleRequestSchema.safeParse(body);
+    if (!validation.success) {
+        throw new ApiError(
+            'VALIDATION_ERROR',
+            `Invalid query: ${formatZodError(validation.error)}`,
+            400
+        );
+    }
+
+    const { sqlQuery, limit } = validation.data;
+    const client = c.get('client');
+
+    const [dataFrame, error] = await client.freestyleQuery(sqlQuery, limit);
+
+    if (error) {
+        throw new ApiError('UNKNOWN_ERROR', error.message, 500, error.cause);
+    }
+
+    return c.json({
+        success: true as const,
+        data: dataFrame satisfies FreestyleResponse,
+    });
+}

--- a/src/server/routes/preview/freestyle.ts
+++ b/src/server/routes/preview/freestyle.ts
@@ -15,6 +15,7 @@ import type { RouteContext } from '../types';
 export const freestyleRequestSchema = z.object({
     sqlQuery: z.string().min(1),
     limit: z.number().positive().max(50000).optional(),
+    timeout: z.number().positive().max(300000).optional(),
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -39,10 +40,10 @@ export async function freestyleHandler(c: RouteContext) {
         );
     }
 
-    const { sqlQuery, limit } = validation.data;
+    const { sqlQuery, limit, timeout } = validation.data;
     const client = c.get('client');
 
-    const [dataFrame, error] = await client.freestyleQuery(sqlQuery, limit);
+    const [dataFrame, error] = await client.freestyleQuery(sqlQuery, limit, timeout);
 
     if (error) {
         throw new ApiError('UNKNOWN_ERROR', error.message, 500, error.cause);

--- a/src/server/routes/preview/index.ts
+++ b/src/server/routes/preview/index.ts
@@ -5,3 +5,4 @@
 export { dataHandler, type DataPreviewResponse } from './data';
 export { distinctHandler, distinctRequestSchema, type DistinctResponse } from './distinct';
 export { countHandler, countRequestSchema, type CountResponse } from './count';
+export { freestyleHandler, freestyleRequestSchema, type FreestyleResponse } from './freestyle';


### PR DESCRIPTION
# Summary
- Adds a new POST `/preview/freestyle` route that exposes SAP ADT's `/sap/bc/adt/datapreview/freestyle` endpoint, enabling full OpenSQL queries including `COUNT`, `SUM`, `GROUP BY`, and multi-line statements — which the existing /preview/data endpoint does not support. This was necessary to allow the test suite to run complex queries for various test cases.
- Adds `freestyleQuery(sqlQuery, limit?)` to the ADTClient interface and implementation
- Fixes `app.onError` to forward `ApiError` message, code, and details instead of returning a hardcoded `"Internal server error"`, so SAP error responses are visible to callers
- Attaches the raw SAP XML response as `details` on errors from the freestyle endpoint, so clients can inspect the exact SAP error
- This was necessary to allow the test suite to identify different errors before proceeding, such as the "subroutine pool exhausted" errors or column name not found.
- For freestyle requests, it overrides to stateless (the regular default) so SAP can route each query to any available work process. Otherwise, we run into ABAP subroutine pool exhaustion on stateful queries.

# Tested
 - POST /preview/freestyle with a valid SELECT returns data
 - POST /preview/freestyle with an invalid SQL returns 500 with error and details fields populated
 - Existing /preview/data, /preview/count, /preview/distinct routes unaffected
 - bun run typecheck passes with zero errors
<img width="1058" height="767" alt="image" src="https://github.com/user-attachments/assets/03feaeae-acad-4994-84ca-d7a50878e3b9" />
